### PR TITLE
Updating Ops Manager Compatibility matrix

### DIFF
--- a/docs-content/index.html.md.erb
+++ b/docs-content/index.html.md.erb
@@ -71,7 +71,7 @@ Before installing the MongoDB Enterprise Service for Pivotal Platform tile, you 
 The tile integrates your Pivotal Platform environment with MongoDB Ops Manager through published REST APIs.
 
 Download MongoDB Ops Manager from [MongoDB](https://www.mongodb.com/download-center#ops-manager), and follow the [MongoDB documentation](https://docs.opsmanager.mongodb.com/current/installation/) to install it.
-MongoDB Ops Manager is not istalled byt PCF Tile and must be provisioned outside of PCF Cluster.
+MongoDB Ops Manager is not istalled by the Pivotal Platform Tile and must be provisioned outside of Pivotal Platform Cluster.
 
 A prerequisite for the use of Ops Manager and MongoDB Enterprise Service for Pivotal Platform in production is an Enterprise Advanced Subscription that covers all MongoDB instances.
 See the [License](#license) section for more information.
@@ -83,7 +83,7 @@ The MongoDB Enterprise Service for Pivotal Platform has the following limitation
 * Standalone and Replica set plans are pre-configured to one and three nodes respectively.
 * It uses only one stemcell.
 * Support for creating blank MongoDB agent VMs is not available.
-* MongoDB Ops Manager functionality and features are limited when used with MongoDB PCF Tile. 
+* MongoDB Ops Manager functionality and features are limited when used with MongoDB Pivotal Platform Tile. 
 
 ## <a id="feedback"></a>Feedback
 

--- a/docs-content/index.html.md.erb
+++ b/docs-content/index.html.md.erb
@@ -38,7 +38,7 @@ The following table provides version and version-support information about Mongo
     </tr>
     <tr>
         <td>Compatible MongoDB Ops Manager version(s)</td>
-        <td>3.6.2+</td>
+        <td>3.6, 4.0</td>
     </tr>
     <tr>
         <td>Compatible Ops Manager versions</td>

--- a/docs-content/index.html.md.erb
+++ b/docs-content/index.html.md.erb
@@ -26,19 +26,19 @@ The following table provides version and version-support information about Mongo
     <th>Details</th>
     <tr>
         <td>Version</td>
-        <td>v1.1.1</td>
+        <td>v1.1.3</td>
     </tr>
     <tr>
         <td>Release date</td>
-        <td>July 11, 2019</td>
+        <td>November 13, 2019</td>
     </tr>
     <tr>
         <td>Compatible MongoDB version(s)</td>
-        <td>3.2.x, 3.4.x, 3.6.x, and 4.0 Enterprise</td>
+        <td>3.4.x, 3.6.x, and 4.0 Enterprise</td>
     </tr>
     <tr>
         <td>Compatible MongoDB Ops Manager version(s)</td>
-        <td>3.6, 4.0</td>
+        <td>4.0</td>
     </tr>
     <tr>
         <td>Compatible Ops Manager versions</td>
@@ -71,6 +71,7 @@ Before installing the MongoDB Enterprise Service for PCF tile, you must download
 The tile integrates your PCF environment with MongoDB Ops Manager through published REST APIs.
 
 Download MongoDB Ops Manager from [MongoDB](https://www.mongodb.com/download-center#ops-manager), and follow the [MongoDB documentation](https://docs.opsmanager.mongodb.com/current/installation/) to install it.
+MongoDB Ops Manager is not istalled byt PCF Tile and must be provisioned outside of PCF Cluster.
 
 A prerequisite for the use of Ops Manager and MongoDB Enterprise Service for PCF in production is an Enterprise Advanced Subscription that covers all MongoDB instances.
 See the [License](#license) section for more information.
@@ -82,6 +83,7 @@ The MongoDB Enterprise Service for PCF has the following limitations:
 * Standalone and Replica set plans are pre-configured to one and three nodes respectively.
 * It uses only one stemcell.
 * Support for creating blank MongoDB agent VMs is not available.
+* MongoDB Ops Manager functionality and features are limited when used with MongoDB PCF Tile. 
 
 ## <a id="feedback"></a>Feedback
 

--- a/docs-content/installing.html.md.erb
+++ b/docs-content/installing.html.md.erb
@@ -69,7 +69,7 @@ This section describes how to troubleshoot known issues when installing the Mong
 
 ### Symptom
 
-MongoDB Ops Manager is not found.
+cf create-service fails with immidiate error that contains: "Service broker error: could not create new group "
 
 ### Explanation
 
@@ -82,25 +82,47 @@ The problem may be produced by one of the following causes:
 ### Solution
 
 1. Ensure that MongoDB Ops Manager is running and reachable across the network.
+  * check that ops Manager url is accesable form MongoDB Tile vm.
 
 1. Navigate to **Group Settings** in MongoDB Ops Manager and ensure that you have **Public API** enabled.
 
 1. Ensure that the MongoDB Ops Manager API key you provided when configuring the tile is valid. If not, navigate to **Group Settings** in MongoDB Ops Manager and generate a new one.
 
+
 ### Symptom
 
-Undetermined error.
+cf create-service fails to deploy. cf service instance has status "create failed"
 
 ### Explanation
 
-Various errors can occur due to misconfiguration, networking issue, or other problems.
+There could be a variety of reasons why service instance fails to dpeloy. A deep dive is required to root casue an issue.
 
 ### Solution
 
-1. Check logs for errors. From the PCF side, you can find logs in the `/var/vcar/sys/log` directory. Alternativly bosh log command can collect all logs for a deployment.
+Here are common step that will help to find an acutall issue
 
-1. Find the task ID of your provisioning job from the output of the `bosh tasks` command. You can then view logs from the task with the command `bosh task <TASK_ID>`.
+1. Run command cf server <service instance name>  and get dashboard url
+1. Use dashboard url to connect to Ops Manager and inspect MongoDB cluster. 
+  * Check that all requires servers has been created and are active. If a cluster has no servers registered, then move to step 4.
+  * Check that MongoDB Agents are connected and report no errors. In most cases MongoDB Agent logs help to identify root cause of an issue. If MongoDB Agents did nto connect, then move to Step 4
+  * If cluster is properly configures but can not reach its "Goal State", please inspect BOSH logs for VM level errors
+1. In case when MongoDB Ops Manager does not register and servers in a cluster a VM level Logs must be inspected
+1. Collect BOSH logs with bosh logs command from Mongo or get them from log collection pipeline, when configured.
+  * Logs from MongoDB tile VM to find out early stage errors
+  * Logs from Server Instances can pin point environmental type errors.
 
-1. On your Ops Manager machine, depending on your installation method, logs can be found for archive installs and package manager installs:
-    * For archive installs: `<ARCHIVE_DIR>/logs`
-    * For package manager installs: `/var/log/mongodb-mms`
+
+
+### Symptom
+
+Following Error appears in Tile logs
+ERROR: Configuration was not applied! 
+
+### Explanation
+
+When cluster configuration has been modified outside of Tile configuration, it may lead to issues with Tile Upgrade. Some configurations performed manully can not be reverted back or not supported by PCF Tile.
+In this case Ops Manager cluster configuration will take priority as it will guarantee no downtile of a deployment.
+
+### Solution
+
+We expect to improve error handling in our following releases to make it clear when configuration is dessyncronized.

--- a/docs-content/installing.html.md.erb
+++ b/docs-content/installing.html.md.erb
@@ -63,13 +63,14 @@ applications and MongoDB databases.
 
 1. After the installation finishes, see [Creating and Binding MongoDB Service Instances](binding.html) for how to create and bind MongoDB service instances.
 
+
 ## <a id="troubleshoot"></a> Troubleshooting
 
 This section describes how to troubleshoot known issues when installing the MongoDB Enterprise Service for PCF tile.
 
 ### Symptom
 
-cf create-service fails with immidiate error that contains: "Service broker error: could not create new group "
+cf create-service fails with immediate error that contains: "Service broker error: could not create new group "
 
 ### Explanation
 
@@ -82,7 +83,7 @@ The problem may be produced by one of the following causes:
 ### Solution
 
 1. Ensure that MongoDB Ops Manager is running and reachable across the network.
-  * check that ops Manager url is accesable form MongoDB Tile vm.
+  * check that ops Manager url is accessible form MongoDB Tile vm.
 
 1. Navigate to **Group Settings** in MongoDB Ops Manager and ensure that you have **Public API** enabled.
 
@@ -95,17 +96,17 @@ cf create-service fails to deploy. cf service instance has status "create failed
 
 ### Explanation
 
-There could be a variety of reasons why service instance fails to dpeloy. A deep dive is required to root casue an issue.
+There could be a variety of reasons why service instance fails to deploy. A deep dive is required to root cause an issue.
 
 ### Solution
 
-Here are common step that will help to find an acutall issue
+Here are common steps that will help to find an actual issue.
 
 1. Run command cf server <service instance name>  and get dashboard url
 1. Use dashboard url to connect to Ops Manager and inspect MongoDB cluster. 
   * Check that all requires servers has been created and are active. If a cluster has no servers registered, then move to step 4.
-  * Check that MongoDB Agents are connected and report no errors. In most cases MongoDB Agent logs help to identify root cause of an issue. If MongoDB Agents did nto connect, then move to Step 4
-  * If cluster is properly configures but can not reach its "Goal State", please inspect BOSH logs for VM level errors
+  * Check that MongoDB Agents are connected and report no errors. In most cases MongoDB Agent logs help to identify root cause of an issue. If MongoDB Agents did not connect, then move to Step 4
+  * If cluster is properly configured but cannot reach its "Goal State", please inspect BOSH logs for VM level errors
 1. In case when MongoDB Ops Manager does not register and servers in a cluster a VM level Logs must be inspected
 1. Collect BOSH logs with bosh logs command from Mongo or get them from log collection pipeline, when configured.
   * Logs from MongoDB tile VM to find out early stage errors
@@ -120,9 +121,9 @@ ERROR: Configuration was not applied!
 
 ### Explanation
 
-When cluster configuration has been modified outside of Tile configuration, it may lead to issues with Tile Upgrade. Some configurations performed manully can not be reverted back or not supported by PCF Tile.
-In this case Ops Manager cluster configuration will take priority as it will guarantee no downtile of a deployment.
+When cluster configuration has been modified outside of Tile configuration, it may lead to issues with Tile Upgrade. Some configurations performed manually cannot be reverted back or not supported by PCF Tile.
+In this case Ops Manager cluster configuration will take priority as it will guarantee no downtime of a deployment.
 
 ### Solution
 
-We expect to improve error handling in our following releases to make it clear when configuration is dessyncronized.
+We expect to improve error handling in our following releases to make it clear when configuration is desynchronized.

--- a/docs-content/installing.html.md.erb
+++ b/docs-content/installing.html.md.erb
@@ -121,7 +121,7 @@ ERROR: Configuration was not applied!
 
 ### Explanation
 
-When cluster configuration has been modified outside of Tile configuration, it may lead to issues with Tile Upgrade. Some configurations performed manually cannot be reverted back or not supported by PCF Tile.
+When cluster configuration has been modified outside of Tile configuration, it may lead to issues with Tile Upgrade. Some configurations performed manually cannot be reverted back or not supported by Pivotal Platform Tile.
 In this case Ops Manager cluster configuration will take priority as it will guarantee no downtime of a deployment.
 
 

--- a/docs-content/parameter-reference.html.md.erb
+++ b/docs-content/parameter-reference.html.md.erb
@@ -47,4 +47,4 @@ to start in a sharded cluster.
 
 * `ssl_enabled` - true|false - Determines if SSL/TLS connections are enabled for this MongoDB deployment. Default controlled by tile-level setting.
 
-* `bosh_dns_disable` - true|false - Determines if Bosh DNS is disabled. False by default. PCF 2.5 this option should not be used. It will be depricated next release. 
+* `bosh_dns_disable` - true|false - Determines if Bosh DNS is disabled. False by default. Pivotal Platform 2.5 this option should not be used. It will be depricated next release. 

--- a/docs-content/parameter-reference.html.md.erb
+++ b/docs-content/parameter-reference.html.md.erb
@@ -47,4 +47,4 @@ to start in a sharded cluster.
 
 * `ssl_enabled` - true|false - Determines if SSL/TLS connections are enabled for this MongoDB deployment. Default controlled by tile-level setting.
 
-* `bosh_dns_disable` - true|false - Determines if Bosh DNS is disabled. False by default.
+* `bosh_dns_disable` - true|false - Determines if Bosh DNS is disabled. False by default. PCF 2.5 this option should not be used. It will be depricated next release. 

--- a/docs-content/release-notes.html.md.erb
+++ b/docs-content/release-notes.html.md.erb
@@ -6,10 +6,10 @@ owner: Partners
 
 **Release Date**: November 13, 2019
 
-* Fixing issue with MongoDB Agent access to local volumes that prevent automated update.
-* Removing quota of 10 sharded cluster deployments. It is now unlimited.
-* OSB Binding command include url parameter that contains sample of a connection string. Note: Connection string should be built separatelly to ensure correct connection for each idividual case.
-* Added additional error resolution for Service Instance upgrade. When MongoDB cluster configuration can not be modified by Tile, Ops Manager will rever to latet known workin configuration in order to avoid service downtime.  
+* Fixing issue with MongoDB Agent write permissions to local volumes that prevent automated update.
+* Removing quota limit of 10 sharded cluster deployments. 
+* OSB Binding command includes url parameter that contains sample of a connection string. Note: Connection string should be built separately to ensure correct connection for each individual case.
+* Added additional error resolution for Service Instance upgrade. When MongoDB cluster configuration cannot be modified by Tile, Ops Manager will revert it to a latest known working configuration in order to avoid service downtime.  
 
 
 ### v1.1.1

--- a/docs-content/release-notes.html.md.erb
+++ b/docs-content/release-notes.html.md.erb
@@ -2,6 +2,15 @@
 title: Release Notes
 owner: Partners
 ---
+### v1.1.3
+
+**Release Date**: November 13, 2019
+
+* Fixing issue with MongoDB Agent access to local volumes that prevent automated update.
+* Removing quota of 10 sharded cluster deployments. It is now unlimited.
+* OSB Binding command include url parameter that contains sample of a connection string. Note: Connection string should be built separatelly to ensure correct connection for each idividual case.
+* Added additional error resolution for Service Instance upgrade. When MongoDB cluster configuration can not be modified by Tile, Ops Manager will rever to latet known workin configuration in order to avoid service downtime.  
+
 
 ### v1.1.1
 


### PR DESCRIPTION
To avoid confusion about Mongodb Ops Manager compatibility since the latest version has been released.